### PR TITLE
Output multiple IPs if answers contain multiple IPs

### DIFF
--- a/aioresolver.py
+++ b/aioresolver.py
@@ -136,17 +136,19 @@ class AioResolver(object):
                     if query_record == 1 or query_record == 5: 
                         self.resolved_hosts += 1
                         if query_record == 1:
-                            ip = answer[3][0]
-                            if ip is None:
+                            ips = answer[3]
+                            if ips[0] is None:
                                 not_alive_host = host # Returns Not Alive hosts do whatever you want to do with it.
                             else:
                                 if self.track:
-                                    if ip in self.trackingdict:
-                                        self.trackingdict[ip].append(host)
-                                    else:
-                                        self.trackingdict[ip] = [host]
+                                    ips = answer[3]
+                                    for ip in ips:
+                                        if ip in self.trackingdict:
+                                            self.trackingdict[ip].append(host)
+                                        else:
+                                            self.trackingdict[ip] = [host]
                                 elif self.resp:
-                                    print("{},{}".format(host, ip)) 
+                                    print("{},{}".format(host, ",".join(ips)))
                                     if self.out_file:
                                         out_file.write("{},{}\n".format(host, ip)) 
                                 else:

--- a/aioresolver.py
+++ b/aioresolver.py
@@ -150,7 +150,7 @@ class AioResolver(object):
                                 elif self.resp:
                                     print("{},{}".format(host, ",".join(ips)))
                                     if self.out_file:
-                                        out_file.write("{},{}\n".format(host, ip)) 
+                                        out_file.write("{},{}\n".format(host, ",".join(ips))) 
                                 else:
                                     print(host)
                                     if self.out_file:


### PR DESCRIPTION
If the DNS answer contains multiple IPs, the output will show all IPs comma-separated. For example:
```
root@localhost:~/aioresolver# python3 aioresolver.py -f domains.txt -resp -s 2>/dev/null
hackerone.com,104.16.99.52,104.16.100.52
techkranti.com,172.67.129.167,104.21.1.170
```

These individual IPs also get added to the `trackingdict` for handling the `-t` argument.